### PR TITLE
edit.py Update

### DIFF
--- a/megacron/edit.py
+++ b/megacron/edit.py
@@ -48,7 +48,7 @@ def process_edits(uid, tb_file, using_remote_file):
             interval = string.joinfields(tmp[:5], ' ')
             cmd = string.joinfields(tmp[5:], ' ')
             try:
-                valid_interval = croniter(interval)
+                croniter(interval)
             except (KeyError, ValueError):
                 while True:
                     # Different syntax in Python 3 'input()'


### PR DESCRIPTION
edit.py now checks validity of jobs, prompts user to correct invalid crontabs, and opens the crontab via preferred text editor, if available. Otherwise it prompts user to set a preferred text editor and exits. If anything looks off feel free to comment.
