### PR TITLE
Modify daemon to act as a well behaved Unix daemon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Set the location of the database file to a shared filesystem in
 
 ::
 
-    sudo megacrond&
+    sudo megacrond
     sudo megacrontab
 
 Commands

--- a/megacron/daemon/main.py
+++ b/megacron/daemon/main.py
@@ -1,7 +1,12 @@
 import sys
+import os
 import signal
 import sched
 import time
+import argparse
+
+import daemon
+from lockfile.pidlockfile import PIDLockFile
 
 from megacron.daemon import scheduler, worker
 
@@ -12,12 +17,32 @@ def _signal_handler(signal, frame):
 
 
 def main():
-    signal.signal(signal.SIGINT, _signal_handler)
-    events = sched.scheduler(time.time, time.sleep)
+    parser = argparse.ArgumentParser(
+        description='A distributed cron-like daemon')
+    parser.add_argument('-f', dest='foreground', action='store_const',
+                        const=False, help='run in foreground')
+    args = parser.parse_args()
 
-    scheduler.check_scheduler(events)
+    if os.geteuid() != 0:
+        sys.exit('%s must be run as root.' % os.path.basename(sys.argv[0]))
 
-    worker.heartbeat(events)
-    worker.update_schedules(events)
+    context = daemon.DaemonContext(
+        pidfile=PIDLockFile('/var/run/megacron.pid'),
+        detach_process=args.foreground,
+    )
+    context.signal_map = {
+        signal.SIGINT: _signal_handler,
+        signal.SIGTERM: _signal_handler
+    }
 
-    events.run()
+    with context:
+        worker.init_worker()
+
+        events = sched.scheduler(time.time, time.sleep)
+
+        scheduler.check_scheduler(events)
+
+        worker.heartbeat(events)
+        worker.update_schedules(events)
+
+        events.run()

--- a/megacron/daemon/worker.py
+++ b/megacron/daemon/worker.py
@@ -8,9 +8,12 @@ from megacron import api
 SCHEDULES_UPDATE_INTERVAL = timedelta(seconds=10)
 HEARTBEAT_UPDATE_INTERVAL = timedelta(seconds=10)
 
-worker = api.create_worker()
 _schedules = []
 _run_schedules_event = None
+
+def init_worker():
+    global worker
+    worker = api.create_worker()
 
 
 def cleanup():

--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,18 @@ setup(
             'megacron-status = megacron.status:main'
         ]
     },
-    install_requires=['croniter'],
+    install_requires=[
+        'croniter',
+        'python-daemon',
+        'lockfile'
+    ],
     package_data={
         'megacron': ['conf/megacron.conf']
     },
     data_files=[
         ('/etc', ['megacron/conf/megacron.conf'])
     ],
-    setup_requires = [ "setuptools_git >= 0.3"],
+    setup_requires=["setuptools_git >= 0.3"],
     url='https://www.mediawiki.org/wiki/Facebook_Open_Academy/Cron',
     license='Creative Commons Attribution-Noncommercial-Share Alike license',
     long_description=open('README.rst').read()


### PR DESCRIPTION
Create a well behaved Unix daemon as defined in [PEP 3143](http://legacy.python.org/dev/peps/pep-3143). I am using the [python-daemon](https://pypi.python.org/pypi/python-daemon) library to handle this. The main advantages of this change are that the daemon will:
- Fork process into the background (-f command line parameter allows it to still run in foreground)
- Disassociates from the terminal
- Create a PID file
- Ensure that the it is run by the root user
